### PR TITLE
Add missing condition for StreamBlockComparison

### DIFF
--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -74,6 +74,8 @@ def get_comparison_class_for_block(block):
         return RichTextBlockComparison
     elif isinstance(block, blocks.StructBlock):
         return StructBlockComparison
+    elif isinstance(block, blocks.StreamBlock):
+        return StreamBlockComparison
     else:
         # As all stream field blocks have a HTML representation, fall back to diffing that.
         return RichTextBlockComparison

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -419,6 +419,28 @@ class TestStreamFieldComparison(TestCase):
         self.assertIsInstance(comparison.htmldiff(), SafeString)
         self.assertTrue(comparison.has_changed())
 
+    def test_compare_nested_streamblock_uses_comparison_class(self):
+        field = StreamPage._meta.get_field('body')
+        stream_block = field.stream_block.child_blocks['books']
+        comparison = self.comparison_class(
+            field,
+            StreamPage(body=StreamValue(field.stream_block, [
+                ('books', StreamValue(stream_block, [('title', 'The Old Man and the Sea', '10')]), '1'),
+            ])),
+            StreamPage(body=StreamValue(field.stream_block, [
+                ('books', StreamValue(stream_block, [('author', 'Crime and Punishment', '11')]), '1'),
+            ])),
+        )
+        expected = """
+            <div class="comparison__child-object">
+                <div class="comparison__child-object addition">Crime and Punishment</div>\n
+                <div class="comparison__child-object deletion">The Old Man and the Sea</div>
+            </div>
+        """
+        self.assertHTMLEqual(comparison.htmldiff(), expected)
+        self.assertIsInstance(comparison.htmldiff(), SafeString)
+        self.assertTrue(comparison.has_changed())
+
     def test_compare_imagechooserblock(self):
         image_model = get_image_model()
         test_image_1 = image_model.objects.create(

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -31,7 +31,7 @@ from wagtail.contrib.forms.views import SubmissionsListView
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.contrib.sitemaps import Sitemap
 from wagtail.contrib.table_block.blocks import TableBlock
-from wagtail.core.blocks import CharBlock, RawHTMLBlock, RichTextBlock, StructBlock
+from wagtail.core.blocks import CharBlock, RawHTMLBlock, RichTextBlock, StreamBlock, StructBlock
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page, PageManager, PageQuerySet, Task
 from wagtail.documents.edit_handlers import DocumentChooserPanel
@@ -1012,6 +1012,10 @@ class StreamPage(Page):
             ('price', CharBlock()),
         ])),
         ('raw_html', RawHTMLBlock()),
+        ('books', StreamBlock([
+            ('title', CharBlock()),
+            ('author', CharBlock()),
+        ])),
     ])
 
     api_fields = ('body',)


### PR DESCRIPTION
This will add a missing condition when comparing `StreamBlocks`.
**WIP**: Need to add tests

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
